### PR TITLE
feat: add new-tab icon

### DIFF
--- a/public/assets/images/icons/new-tab.svg
+++ b/public/assets/images/icons/new-tab.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+</svg>


### PR DESCRIPTION
Add `new-tab` icon to `public/assets/images/icons`. 

![Screen Shot 2023-01-18 at 4 20 10 PM](https://user-images.githubusercontent.com/13259201/213300083-79281a3e-4546-44ca-b522-05c899460211.png)

Ticket: https://app.shortcut.com/movableink/story/75333/add-new-tab-icon-to-fluid