### PR TITLE
Allow Both Blocks and Multiple for Multi-Select

### DIFF
--- a/addon-test-support/pages/fluid-select.js
+++ b/addon-test-support/pages/fluid-select.js
@@ -14,12 +14,9 @@ import { assert } from '@ember/debug';
 export const FluidSelect = {
   scope: '.fluid-select',
 
+  // TODO: we should rename this because this function both opens and closes multi-select dropdowns
+  // we should just rename it something like 'toggle'
   async open() {
-    await this.trigger.toggle();
-    return settled();
-  },
-
-  async toggleOpen() {
     await this.trigger.toggle();
     return settled();
   },

--- a/addon-test-support/pages/fluid-select.js
+++ b/addon-test-support/pages/fluid-select.js
@@ -14,7 +14,7 @@ import { assert } from '@ember/debug';
 export const FluidSelect = {
   scope: '.fluid-select',
 
-  async open() {
+  async toggleOpen() {
     await this.trigger.toggle();
     return settled();
   },

--- a/addon-test-support/pages/fluid-select.js
+++ b/addon-test-support/pages/fluid-select.js
@@ -14,6 +14,11 @@ import { assert } from '@ember/debug';
 export const FluidSelect = {
   scope: '.fluid-select',
 
+  async open() {
+    await this.trigger.toggle();
+    return settled();
+  },
+
   async toggleOpen() {
     await this.trigger.toggle();
     return settled();

--- a/addon/components/fluid-checkbox.hbs
+++ b/addon/components/fluid-checkbox.hbs
@@ -2,7 +2,7 @@
   class="fluid-checkbox
     {{if @checked "fluid-checkbox--checked"}}
     {{if @disabled "fluid-checkbox--disabled"}}
-    "
+    {{@defaultClass}}"
   @isOn={{@checked}}
   @onUpdate={{@onchange}}
   ...attributes

--- a/addon/components/fluid-checkbox.js
+++ b/addon/components/fluid-checkbox.js
@@ -1,3 +1,3 @@
-import Component from '@ember/component';
+import templateOnly from '@ember/component/template-only';
 
-export default class FluidCheckbox extends Component {}
+export default templateOnly();

--- a/addon/components/fluid-checkbox.js
+++ b/addon/components/fluid-checkbox.js
@@ -1,6 +1,3 @@
-// import templateOnly from '@ember/component/template-only';
-
-// export default templateOnly();
 import Component from '@ember/component';
 
 export default class FluidCheckbox extends Component {}

--- a/addon/components/fluid-checkbox.js
+++ b/addon/components/fluid-checkbox.js
@@ -1,3 +1,6 @@
-import templateOnly from '@ember/component/template-only';
+// import templateOnly from '@ember/component/template-only';
 
-export default templateOnly();
+// export default templateOnly();
+import Component from '@ember/component';
+
+export default class FluidCheckbox extends Component {}

--- a/addon/components/fluid-select.hbs
+++ b/addon/components/fluid-select.hbs
@@ -3,6 +3,7 @@
     class="w-full"
     @renderInPlace={{@renderInPlace}}
     @onOpen={{action (optional @onOpen)}}
+    @onClose={{action (optional @onClose)}}
     @triggerComponent={{component "fluid-select/trigger"}}
     @matchTriggerWidth={{@matchTriggerWidth}}
     as |dropdown|

--- a/addon/components/fluid-select/list.hbs
+++ b/addon/components/fluid-select/list.hbs
@@ -1,6 +1,6 @@
 <div class="fluid-select__list py-2" ...attributes>
   {{#if (has-block)}}
-    {{yield}}
+    {{yield @options @select}}
   {{else if (or @loading (is-pending @options))}}
     <label class="fluid-select__list-item fluid-select__list-item--loading inline-flex">
       {{svg-jar "loading" class="mr-2 w-4 fill-neutral-500"}}

--- a/addon/components/fluid-select/option.hbs
+++ b/addon/components/fluid-select/option.hbs
@@ -3,8 +3,8 @@
     (hash
       checkbox=(component
         "fluid-checkbox"
-        class=(concat
-          "pl-4 pr-6 fluid-select__option fluid-checkbox"
+        defaultClass=(concat
+          "pl-4 pr-6 fluid-select__option"
           (if @dark " fluid-select__option--dark")
           (if this.isSelected this.selectedClass)
         )

--- a/addon/components/fluid-select/option.hbs
+++ b/addon/components/fluid-select/option.hbs
@@ -1,4 +1,6 @@
-{{#if (has-block)}}
+{{#if (and (has-block) @mutliple)}}
+  {{yield (component "fluid-checkbox")}}
+{{else if (has-block)}}
   <div
     role="button"
     data-test-fluid-select-option={{this.optionLabel}}

--- a/addon/components/fluid-select/option.hbs
+++ b/addon/components/fluid-select/option.hbs
@@ -1,5 +1,19 @@
-{{#if (and (has-block) @mutliple)}}
-  {{yield (component "fluid-checkbox")}}
+{{#if (and (has-block) @multiple)}}
+  {{yield
+    (hash
+      checkbox=(component
+        "fluid-checkbox"
+        class=(concat
+          "pl-4 pr-6 fluid-select__option"
+          (if @dark " fluid-select__option--dark")
+          (if this.isSelected this.selectedClass)
+        )
+        label=this.optionLabel
+        checked=this.isSelected
+        onchange=(action @select @option)
+      )
+    )
+  }}
 {{else if (has-block)}}
   <div
     role="button"

--- a/addon/components/fluid-select/option.hbs
+++ b/addon/components/fluid-select/option.hbs
@@ -4,7 +4,7 @@
       checkbox=(component
         "fluid-checkbox"
         class=(concat
-          "pl-4 pr-6 fluid-select__option"
+          "pl-4 pr-6 fluid-select__option fluid-checkbox"
           (if @dark " fluid-select__option--dark")
           (if this.isSelected this.selectedClass)
         )

--- a/tests/integration/components/fluid-select-test.js
+++ b/tests/integration/components/fluid-select-test.js
@@ -242,7 +242,7 @@ module('Integration | Component | fluid-select', function (hooks) {
                 @select={{action selectCheckbox}}
                 as |fo|
               >
-                <fo.checkbox>{{option}}</fo.checkbox>
+                <fo.checkbox @label={{option}} />
               </FluidSelect::Option>
             {{/each}}
           </fs.list>

--- a/tests/integration/components/fluid-select-test.js
+++ b/tests/integration/components/fluid-select-test.js
@@ -23,7 +23,7 @@ module('Integration | Component | fluid-select', function (hooks) {
 
     await percySnapshot(assert, 'trigger');
 
-    await component.open();
+    await component.toggleOpen();
 
     await percySnapshot(assert, 'popup');
 
@@ -52,7 +52,7 @@ module('Integration | Component | fluid-select', function (hooks) {
     });
 
     await render(hbs`<FluidSelect @onOpen={{action testOnOpen}} />`);
-    await component.open();
+    await component.toggleOpen();
     assert.ok(component.popup.isVisible, 'the popup still opens');
   });
 
@@ -79,7 +79,7 @@ module('Integration | Component | fluid-select', function (hooks) {
     );
 
     await render(hbs`<FluidSelect @options={{promise}} />`);
-    await component.open();
+    await component.toggleOpen();
 
     assert.ok(
       component.popup.loading.isVisible,
@@ -107,7 +107,7 @@ module('Integration | Component | fluid-select', function (hooks) {
     await render(hbs`
       <FluidSelect @select={{select}} @options={{options}} @selected={{selected}} />
     `);
-    await component.open();
+    await component.toggleOpen();
 
     const firstOption = component.popup.list.options[0];
     this.set('select', (value) =>
@@ -117,7 +117,7 @@ module('Integration | Component | fluid-select', function (hooks) {
     await firstOption.click();
 
     assert.ok(component.popup.isHidden, 'the popup closes after selecting an option');
-    await component.open();
+    await component.toggleOpen();
 
     const fourthOption = component.popup.list.options[3];
     this.set('select', (value) =>
@@ -135,7 +135,7 @@ module('Integration | Component | fluid-select', function (hooks) {
     await render(hbs`
       <FluidSelect @options={{options}} @select={{select}} @labelPath={{labelPath}} />
     `);
-    await component.open();
+    await component.toggleOpen();
 
     const firstOption = component.popup.list.options[0];
     assert.equal(firstOption.text, 'one');
@@ -166,7 +166,7 @@ module('Integration | Component | fluid-select', function (hooks) {
       await render(hbs`
         <FluidSelect @options={{groups}} @select={{select}} @selected={{selected}} />
       `);
-      await component.open();
+      await component.toggleOpen();
 
       await percySnapshot(assert);
 
@@ -201,7 +201,7 @@ module('Integration | Component | fluid-select', function (hooks) {
       await render(hbs`
         <FluidSelect @options={{groups}} @select={{select}} @selected={{selected}} />
       `);
-      await component.open();
+      await component.toggleOpen();
 
       assert.equal(
         component.popup.list.options.length,
@@ -253,7 +253,7 @@ module('Integration | Component | fluid-select', function (hooks) {
       assert.equal(component.trigger.text, 'Fruit', 'the trigger has the passed label');
       assert.ok(component.popup.isHidden, 'the popup is hidden');
 
-      await component.open();
+      await component.toggleOpen();
 
       assert.equal(
         component.popup.list.options.length,
@@ -274,7 +274,7 @@ module('Integration | Component | fluid-select', function (hooks) {
       await render(hbs`
         <FluidSelect @options={{options}} @selected={{selected}} @select={{select}} @multiple={{true}} />
       `);
-      await component.open();
+      await component.toggleOpen();
 
       await percySnapshot(assert);
 
@@ -290,7 +290,7 @@ module('Integration | Component | fluid-select', function (hooks) {
       await render(hbs`
         <FluidSelect @options={{options}} @selected={{selected}} @select={{select}} @multiple={{true}} />
       `);
-      await component.open();
+      await component.toggleOpen();
 
       assert.equal(component.popup.list.selectedOptions.length, 1);
 
@@ -322,7 +322,7 @@ module('Integration | Component | fluid-select', function (hooks) {
         await render(hbs`
           <FluidSelect @options={{options}} @search={{search}} @select={{action (mut selected)}} />
         `);
-        await component.open();
+        await component.toggleOpen();
 
         await percySnapshot(assert, 'no search term & results');
 
@@ -385,7 +385,7 @@ module('Integration | Component | fluid-select', function (hooks) {
         await render(hbs`
           <FluidSelect @options={{options}} @search={{asyncSearch}} @select={{action (mut selected)}} />
         `);
-        await component.open();
+        await component.toggleOpen();
         await component.popup.search.fillIn('anything');
 
         assert.ok(
@@ -441,7 +441,7 @@ module('Integration | Component | fluid-select', function (hooks) {
       assert.equal(component.trigger.text, 'Click Me!', 'the trigger has the passed label');
       assert.ok(component.popup.isHidden, 'the popup is hidden');
 
-      await component.open();
+      await component.toggleOpen();
 
       assert.ok(component.popup.isVisible, 'the popup shows when the custom trigger is clicked');
       assert.equal(

--- a/tests/integration/components/fluid-select-test.js
+++ b/tests/integration/components/fluid-select-test.js
@@ -224,30 +224,30 @@ module('Integration | Component | fluid-select', function (hooks) {
 
     test.only('block mode with custom options and checkbox labels', async function (assert) {
       await render(hbs`<FluidSelect
-  @options={{this.options}}
-  @select={{this.select}}
-  @selected={{this.selected}}
-  @multiple={{true}}
-  as |fs|
->
-  <fs.trigger @label='Fruit' />
-  <fs.popup>
-    <fs.list @multiple={{true}} as |options selectCheckbox|>
-      {{#each options as |option|}}
-        <FluidSelect::Option
-          @dark={{@dark}}
-          @option={{option}}
-          @selected={{this.selected}}
-          @multiple={{true}}
-          @select={{action selectCheckbox}}
-          as |fo|
-        >
-          <fo.checkbox>{{option}}</fo.checkbox>
-        </FluidSelect::Option>
-      {{/each}}
-    </fs.list>
-  </fs.popup>
-</FluidSelect>`);
+        @options={{this.options}}
+        @select={{this.select}}
+        @selected={{this.selected}}
+        @multiple={{true}}
+        as |fs|
+      >
+        <fs.trigger @label='Fruit' />
+        <fs.popup>
+          <fs.list @multiple={{true}} as |options selectCheckbox|>
+            {{#each options as |option|}}
+              <FluidSelect::Option
+                @dark={{@dark}}
+                @option={{option}}
+                @selected={{this.selected}}
+                @multiple={{true}}
+                @select={{action selectCheckbox}}
+                as |fo|
+              >
+                <fo.checkbox>{{option}}</fo.checkbox>
+              </FluidSelect::Option>
+            {{/each}}
+          </fs.list>
+        </fs.popup>
+      </FluidSelect>`);
 
       assert.ok(component.trigger.isVisible, 'the trigger renders');
       assert.equal(component.trigger.text, 'Fruit', 'the trigger has the passed label');

--- a/tests/integration/components/fluid-select-test.js
+++ b/tests/integration/components/fluid-select-test.js
@@ -15,8 +15,12 @@ module('Integration | Component | fluid-select', function (hooks) {
     this.set('select', (value) => this.set('selected', value));
   });
 
-  test('it renders', async function (assert) {
-    await render(hbs`<FluidSelect @options={{options}} @select={{select}} />`);
+  test.only('it renders', async function (assert) {
+    await render(hbs`<FluidSelect @options={{options}} @select={{select}} 
+    @multiple={{true}} as |Fc|>
+      <Fc />
+    </FluidSelect>`);
+    await this.pauseTest();
 
     assert.ok(component.trigger.isVisible, 'it renders a trigger button');
     assert.ok(component.popup.isHidden, 'the popup is not visible on render');

--- a/tests/integration/components/fluid-select-test.js
+++ b/tests/integration/components/fluid-select-test.js
@@ -15,12 +15,8 @@ module('Integration | Component | fluid-select', function (hooks) {
     this.set('select', (value) => this.set('selected', value));
   });
 
-  test.only('it renders', async function (assert) {
-    await render(hbs`<FluidSelect @options={{options}} @select={{select}} 
-    @multiple={{true}} as |Fc|>
-      <Fc />
-    </FluidSelect>`);
-    await this.pauseTest();
+  test('it renders', async function (assert) {
+    await render(hbs`<FluidSelect @options={{options}} @select={{select}} />`);
 
     assert.ok(component.trigger.isVisible, 'it renders a trigger button');
     assert.ok(component.popup.isHidden, 'the popup is not visible on render');
@@ -226,10 +222,60 @@ module('Integration | Component | fluid-select', function (hooks) {
       });
     });
 
+    test.only('block mode with custom options and checkbox labels', async function (assert) {
+      await render(hbs`<FluidSelect
+  @options={{this.options}}
+  @select={{this.select}}
+  @selected={{this.selected}}
+  @multiple={{true}}
+  as |fs|
+>
+  <fs.trigger @label='Fruit' />
+  <fs.popup>
+    <fs.list @multiple={{true}} as |options selectCheckbox|>
+      {{#each options as |option|}}
+        <FluidSelect::Option
+          @dark={{@dark}}
+          @option={{option}}
+          @selected={{this.selected}}
+          @multiple={{true}}
+          @select={{action selectCheckbox}}
+          as |fo|
+        >
+          <fo.checkbox>{{option}}</fo.checkbox>
+        </FluidSelect::Option>
+      {{/each}}
+    </fs.list>
+  </fs.popup>
+</FluidSelect>`);
+
+      assert.ok(component.trigger.isVisible, 'the trigger renders');
+      assert.equal(component.trigger.text, 'Fruit', 'the trigger has the passed label');
+      assert.ok(component.popup.isHidden, 'the popup is hidden');
+
+      await component.open();
+
+      assert.equal(
+        component.popup.list.options.length,
+        this.get('options.length'),
+        'the correct number of options render'
+      );
+
+      const firstOption = component.popup.list.options[0];
+      await firstOption.click();
+
+      const fourthOption = component.popup.list.options[3];
+      await fourthOption.click();
+
+      await this.pauseTest();
+      assert.equal(component.popup.list.selectedOptions.length, 2);
+    });
+
     test('checkboxes', async function (assert) {
       await render(hbs`
         <FluidSelect @options={{options}} @selected={{selected}} @select={{select}} @multiple={{true}} />
       `);
+      await this.pauseTest();
       await component.open();
 
       await percySnapshot(assert);

--- a/tests/integration/components/fluid-select-test.js
+++ b/tests/integration/components/fluid-select-test.js
@@ -222,7 +222,7 @@ module('Integration | Component | fluid-select', function (hooks) {
       });
     });
 
-    test.only('block mode with custom options and checkbox labels', async function (assert) {
+    test('block mode with custom options and checkbox labels', async function (assert) {
       await render(hbs`<FluidSelect
         @options={{this.options}}
         @select={{this.select}}
@@ -267,7 +267,6 @@ module('Integration | Component | fluid-select', function (hooks) {
       const fourthOption = component.popup.list.options[3];
       await fourthOption.click();
 
-      await this.pauseTest();
       assert.equal(component.popup.list.selectedOptions.length, 2);
     });
 
@@ -275,7 +274,6 @@ module('Integration | Component | fluid-select', function (hooks) {
       await render(hbs`
         <FluidSelect @options={{options}} @selected={{selected}} @select={{select}} @multiple={{true}} />
       `);
-      await this.pauseTest();
       await component.open();
 
       await percySnapshot(assert);

--- a/tests/integration/components/fluid-select-test.js
+++ b/tests/integration/components/fluid-select-test.js
@@ -23,7 +23,7 @@ module('Integration | Component | fluid-select', function (hooks) {
 
     await percySnapshot(assert, 'trigger');
 
-    await component.toggleOpen();
+    await component.open();
 
     await percySnapshot(assert, 'popup');
 
@@ -52,7 +52,7 @@ module('Integration | Component | fluid-select', function (hooks) {
     });
 
     await render(hbs`<FluidSelect @onOpen={{action testOnOpen}} />`);
-    await component.toggleOpen();
+    await component.open();
     assert.ok(component.popup.isVisible, 'the popup still opens');
   });
 
@@ -79,7 +79,7 @@ module('Integration | Component | fluid-select', function (hooks) {
     );
 
     await render(hbs`<FluidSelect @options={{promise}} />`);
-    await component.toggleOpen();
+    await component.open();
 
     assert.ok(
       component.popup.loading.isVisible,
@@ -107,7 +107,7 @@ module('Integration | Component | fluid-select', function (hooks) {
     await render(hbs`
       <FluidSelect @select={{select}} @options={{options}} @selected={{selected}} />
     `);
-    await component.toggleOpen();
+    await component.open();
 
     const firstOption = component.popup.list.options[0];
     this.set('select', (value) =>
@@ -117,7 +117,7 @@ module('Integration | Component | fluid-select', function (hooks) {
     await firstOption.click();
 
     assert.ok(component.popup.isHidden, 'the popup closes after selecting an option');
-    await component.toggleOpen();
+    await component.open();
 
     const fourthOption = component.popup.list.options[3];
     this.set('select', (value) =>
@@ -135,7 +135,7 @@ module('Integration | Component | fluid-select', function (hooks) {
     await render(hbs`
       <FluidSelect @options={{options}} @select={{select}} @labelPath={{labelPath}} />
     `);
-    await component.toggleOpen();
+    await component.open();
 
     const firstOption = component.popup.list.options[0];
     assert.equal(firstOption.text, 'one');
@@ -166,7 +166,7 @@ module('Integration | Component | fluid-select', function (hooks) {
       await render(hbs`
         <FluidSelect @options={{groups}} @select={{select}} @selected={{selected}} />
       `);
-      await component.toggleOpen();
+      await component.open();
 
       await percySnapshot(assert);
 
@@ -201,7 +201,7 @@ module('Integration | Component | fluid-select', function (hooks) {
       await render(hbs`
         <FluidSelect @options={{groups}} @select={{select}} @selected={{selected}} />
       `);
-      await component.toggleOpen();
+      await component.open();
 
       assert.equal(
         component.popup.list.options.length,
@@ -253,7 +253,7 @@ module('Integration | Component | fluid-select', function (hooks) {
       assert.equal(component.trigger.text, 'Fruit', 'the trigger has the passed label');
       assert.ok(component.popup.isHidden, 'the popup is hidden');
 
-      await component.toggleOpen();
+      await component.open();
 
       assert.equal(
         component.popup.list.options.length,
@@ -274,7 +274,7 @@ module('Integration | Component | fluid-select', function (hooks) {
       await render(hbs`
         <FluidSelect @options={{options}} @selected={{selected}} @select={{select}} @multiple={{true}} />
       `);
-      await component.toggleOpen();
+      await component.open();
 
       await percySnapshot(assert);
 
@@ -290,7 +290,7 @@ module('Integration | Component | fluid-select', function (hooks) {
       await render(hbs`
         <FluidSelect @options={{options}} @selected={{selected}} @select={{select}} @multiple={{true}} />
       `);
-      await component.toggleOpen();
+      await component.open();
 
       assert.equal(component.popup.list.selectedOptions.length, 1);
 
@@ -322,7 +322,7 @@ module('Integration | Component | fluid-select', function (hooks) {
         await render(hbs`
           <FluidSelect @options={{options}} @search={{search}} @select={{action (mut selected)}} />
         `);
-        await component.toggleOpen();
+        await component.open();
 
         await percySnapshot(assert, 'no search term & results');
 
@@ -385,7 +385,7 @@ module('Integration | Component | fluid-select', function (hooks) {
         await render(hbs`
           <FluidSelect @options={{options}} @search={{asyncSearch}} @select={{action (mut selected)}} />
         `);
-        await component.toggleOpen();
+        await component.open();
         await component.popup.search.fillIn('anything');
 
         assert.ok(
@@ -441,7 +441,7 @@ module('Integration | Component | fluid-select', function (hooks) {
       assert.equal(component.trigger.text, 'Click Me!', 'the trigger has the passed label');
       assert.ok(component.popup.isHidden, 'the popup is hidden');
 
-      await component.toggleOpen();
+      await component.open();
 
       assert.ok(component.popup.isVisible, 'the popup shows when the custom trigger is clicked');
       assert.equal(


### PR DESCRIPTION
The fluid select is not currently well set up to pass blocks to the fluid-checkbox used in a multi-select in a fluid-select.  We will need to customize the labels for a select that we are converting to a multi-select, and we need to make that process easier in case we do that again in the future.