### PR TITLE
refactor: z-index base of tailwind `z-0`

### DIFF
--- a/addon/components/fluid-tooltip.hbs
+++ b/addon/components/fluid-tooltip.hbs
@@ -2,6 +2,7 @@
   <div
     class="fluid-tooltip bg-neutral-900 text-neutral-100 text-center px-4 py-2 shadow rounded-md body-base"
     data-test-tooltip
+    ...attributes
     {{popper-tooltip this.attachment (popper-modifier "offset" offset=(array 0 16))}}
   >
     <div class="fluid-tooltip-arrow h-4 w-4" data-popper-arrow>

--- a/app/styles/fluid/components/fluid-tooltip.scss
+++ b/app/styles/fluid/components/fluid-tooltip.scss
@@ -1,6 +1,8 @@
 .fluid-tooltip {
+  // WARN:
+  // This is the base class and the lowest in the tailwind docs for cascading styles [0, 10, 20, 40, 50, auto] So if `z-auto` is used then that cannot be overwritten by any other `z-index` tailwind class.
+  @apply z-0;
   max-width: 350px;
-  z-index: 1;
 }
 
 .fluid-tooltip-arrow::before {


### PR DESCRIPTION
This is the base class and the lowest in the
tailwind docs for cascading styles
[0, 10, 20, 40, 50, auto] So if `z-auto` is used
then that cannot be overwritten by any other `z-index` tailwind class.