### PR TITLE
fix(security): vm2 must be ^3.9.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
   "resolutions": {
     "shell-quote": "^1.7.3",
     "testem": "^3.10.0",
-    "socket.io-parser": "^4.2.1"
+    "socket.io-parser": "^4.2.1",
+    "vm2": "^3.9.15"
   },
   "keywords": [
     "ember-addon"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24840,15 +24840,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"vm2@npm:^3.9.8":
-  version: 3.9.9
-  resolution: "vm2@npm:3.9.9"
+"vm2@npm:^3.9.15":
+  version: 3.9.17
+  resolution: "vm2@npm:3.9.17"
   dependencies:
     acorn: ^8.7.0
     acorn-walk: ^8.2.0
   bin:
     vm2: bin/vm2
-  checksum: ea4859565668918b53cf8c087bc18e2a9506f9f4ef919528707a6fecf50a110a2a8c48bc0c7a754c9d12b97cd16775f005b2b941e99d3a52aadfaac5ce77e04d
+  checksum: 9a03740a40ab2be5e3348a95fb31512da1a3c85318febb07e5299fa103ff05bcd7b6f458211fa38a1281dc27beccd04ff90355fc1d34fe2ee6ca10d0bb8c6f35
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2023-29017

[sc-82248]