### PR TITLE
chore: validate Node 24 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "*.{hbs,json,md,yml}": "prettier --write"
   },
   "volta": {
-    "node": "22.21.1",
+    "node": "24.14.0",
     "yarn": "1.22.10"
   },
   "packageManager": "yarn@3.1.1"


### PR DESCRIPTION
## Summary

- Bumps Volta Node pin from 22.21.1 → 24.14.0
- Validates that the broccoli patch + postcss-sass swap from the parent PR works on Node 24 — the actual target for the GitHub Actions deprecation (June 2, 2026)

## Test Results (Node 24.14.0)

| Check | Result |
|-------|--------|
| `yarn install` | ✅ |
| `yarn build` | ✅ |
| `yarn lint-js` | ✅ |
| `yarn lint-hbs` | ✅ |
| `yarn test` | ✅ 85 tests, 84 pass, 1 skip (pre-existing), 0 fail |
| `yarn build-storybook` | ⚠️ Requires `NODE_OPTIONS=--openssl-legacy-provider` — Storybook 6/webpack 4 uses MD4 hashing removed in OpenSSL 3.x. Separate upgrade needed (Storybook 6 → 7+). |

## Test plan

- [x] Build passes on Node 24
- [x] All tests pass on Node 24
- [x] Linting passes on Node 24
- [ ] CI validation

[sc-190048]

🤖 Generated with [Claude Code](https://claude.com/claude-code)